### PR TITLE
fix: 出力されるAmazonのURLが正しくない

### DIFF
--- a/app/utils/bitly_utils.py
+++ b/app/utils/bitly_utils.py
@@ -31,15 +31,14 @@ def make_url_list(asin_list: list) -> list:
     """
     asin 120件ごとに検索結果URLをつくり、URLのリストを返す
     """
-    base_url = "https://www.amazon.co.jp/s?i=digital-text&hidden-keywords="
+    amazon_tag = os.environ["AMAZON_TAG"]
+    base_url = (
+        f"https://www.amazon.co.jp/s?i=digital-text&tag={amazon_tag}&hidden-keywords="
+    )
     url_list = []
     for i, asin in enumerate(asin_list):
         if asin:
             if i % 120 == 0:
-                # 末尾にアソシエイトタグを付与する
-                amazon_tag = os.environ["AMAZON_TAG"]
-                tag = f"&tag={amazon_tag}"
-                base_url += tag
                 url_list.append(base_url)
             url_list[-1] += asin + "|"
     return url_list

--- a/app/utils/scraping_utils.py
+++ b/app/utils/scraping_utils.py
@@ -52,7 +52,7 @@ class BookwalkerScraping:
         if not url.endswith("/"):
             url += "/"
 
-        is_valid_domain = re.match(r"https://bookwalker.jp/.+?/[0-9]+/$", url)
+        is_valid_domain = re.match(r"https://bookwalker.jp/.+?/[0-9]+/.*$", url)
         if not is_valid_domain:
             logger.error(f"Invalid URL: {url}")
             return False


### PR DESCRIPTION
## 症状
- 次のような誤った形式のURLになる
```
https://www.amazon.co.jp/s?i=digital-text&amp;hidden-keywords=&amp;tag=hito-horobe-22B0DY15HSWX|B0DY15991C|B0DY153Y57|B00CA07JLG|B00CA07JKC|B00CA07JJ8|B00CA07JKW|B00CA083B6|B00CA083D4|B00CA083GQ|B00DTOA6BM|B00DTOA6BW|B01ELD407U|B00CA084AQ|B00CA084MO|B00CA084MO|B00CA084M4|B00CA084PQ|B00CA084QA|B00FB2X81U|B00EC84MOQ|B00EC84MSC|B00IZ7R7LK|B00IZ7R7B0|B00MIDW7J4|B015GVZA3E|B0DY15HSWX|B076Q4TVW1|B07JMNT3M8|B07WZK9WR7|B07WPY383J|B00RBC836S|B00RBC83AO|B00RBC83FY|B00RBC83G8|B00VSYP1EC|B01DF0O2UK|B06XG9165L|B00X9CDPE4|B00X9CDPBC|B00X9CDPD0|B00X9CDP8A|B00X9CDP8U|B00X9CDTTU|B00X9CDQCK|B00X9CDQIE|B08S2TFMPW|B08W531T9Q|B09DCPVPBK|B09DG6QXMN|B0BBPJ4L6Q|B09H2TNP84|B09H2T8CRV|B09H2SS1MD|B09TF5Q2Y3|B0BWDZZ5FS|B0D2NSKP1L|
```
- 解消すべきポイント
  - `hidden-keywords=`のあとにasinを並べること
  - tagとasinの間に`&`を入れること 
 
## 対応
- `make_url_list()`の修正
- 結果例
  - https://amzn.to/4hSbbpy
  - 展開後
 ```
https://www.amazon.co.jp/s?i=digital-text&hidden-keywords=B0DY15HSWX%7CB0DY15991C%7CB0DY153Y57%7CB00CA07JLG%7CB00CA07JKC%7CB00CA07JJ8%7CB00CA07JKW%7CB00CA083D4%7CB00CA083GQ%7CB00DTOA6BM%7CB00DTOA6BW%7CB01ELD407U%7CB00CA084MO%7CB00CA084MO%7CB00CA084M4%7CB00CA084PQ%7CB00FB2X81U%7CB00EC84MOQ%7CB00EC84MSC%7CB00IZ7R7LK%7CB00IZ7R7B0%7CB00MIDW7J4%7CB015GVZA3E%7CB0DY15HSWX%7CB076Q4TVW1%7CB07JMNT3M8%7CB07WZK9WR7%7CB07WPY383J%7CB00RBC836S%7CB00RBC83AO%7CB00RBC83FY%7CB00RBC83G8%7CB00VSYP1EC%7CB01DF0O2UK%7CB06XG9165L%7CB00X9CDPE4%7CB00X9CDPBC%7CB00X9CDPD0%7CB00X9CDP8U%7CB00X9CDTTU%7CB00X9CDQCK%7CB00X9CDQIE%7CB08S2TFMPW%7CB08W531T9Q%7CB09DCPVPBK%7CB09DG6QXMN%7CB0BBPJ4L6Q%7CB09H2TNP84%7CB09H2T8CRV%7CB09H2SS1MD%7CB09TF5Q2Y3%7CB0BWDZZ5FS%7CB0D2NSKP1L&tag=hito-horobe-22
```
![image](https://github.com/user-attachments/assets/0481ba3c-e339-401b-b823-77ff04f32c1f)
