### PR TITLE
fix: 【無料お試し】等の文言を含むアイテムを無視しない

### DIFF
--- a/app/utils/scraping_utils.py
+++ b/app/utils/scraping_utils.py
@@ -19,7 +19,7 @@ BOOKWALKER_CAMPAIGN_URL = "https://bookwalker.jp/campaign/"
 TIMEOUT = 10
 
 # 商品名に含まれていたら無視するキーワード一覧
-IGNORE_KEYWORDS = ["分冊版", "試し読み", "無料", "お試し", "期間限定"]
+IGNORE_KEYWORDS = ["分冊版"]
 
 logger = getLogger(__name__)
 
@@ -207,8 +207,8 @@ class BookwalkerScraping:
                         periods.append(period)
 
                 # 商品名に含まれていたら無視するキーワードがあればスキップ
-                # if any(keyword in item_title for keyword in IGNORE_KEYWORDS):
-                #    continue
+                if any(keyword in item_title for keyword in IGNORE_KEYWORDS):
+                   continue
                 bookwalker_item = BookwalkerItemSchema(
                     title=item_title,
                     url=item_url,

--- a/make_kindle_link.py
+++ b/make_kindle_link.py
@@ -1,3 +1,4 @@
+import re
 import argparse
 import time
 from dotenv import load_dotenv
@@ -39,9 +40,10 @@ def main():
     items = campaign.items
     for item in items:
         # 商品情報を出力する
-        # print(item)
+        # item.title のうち【】で囲まれた部分を削除する
         # 商品情報をAmazonで検索する。検索は商品名+レーベル+出版社名で行う
-        keywords = f"{item.title} {item.company}"
+        title = re.sub(r"【.*?】", "", item.title)
+        keywords = f"{title} {item.company}"
         try:
             if item.label:
                 keywords += f" {item.label}"


### PR DESCRIPTION
## 概要
- いままではIGNORE_KEYWORDS にマッチするアイテムを除外していた
  - 試し読み版を除外するため
- しかしブックウォーカーでは【期間限定無料】とついているがAmazonでは通常のコミックスが期間限定無料扱いになっていることがあり、除外したくない

## 対応
- 除外しないことにする
- その代わりAmazonの商品検索時に【】で囲まれているものを削除する